### PR TITLE
Add openai support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,40 @@ https://github.com/LibreTranslate/LibreTranslate
 ```bash
 pip install allianceauth-translate-tool
 ```
-or 
+
+or
+
 ```
 allianceauth-translate-tool==version
 ```
 
 - Add `'aatranslate',` to your INSTALLED_APPS list in local.py.
 
-- Add the below lines to your `local.py` settings file, Changing the contexts to yours.
+- Add or update the following settings in your `local.py` file to configure how translations are performed.
 
 ```python
 ## Settings for AA-Translate-Tool
-# URL of the self hosted libretranslate instance
-AA_TRANSLATIONS_URL = "http://URL_to_api:5000"
-# Optional Api Key
-AA_TRANSLATIONS_API_KEY= "i was generated from libretranslate"
+# Translation provider: "libretranslate" (default) or "openai"
+AA_TRANSLATIONS_PROVIDER = "libretranslate"
+
+# Base URL for the translation API endpoint or the openai compatible endpoint
+AA_TRANSLATIONS_URL = "http://libretranslate:9095"
+
+# API key for your provider. Required for "openai", optional for self-hosted LibreTranslate.
+AA_TRANSLATIONS_API_KEY = None
+
+# Model identifier when using the "openai" provider (e.g. "gpt-4o-mini")
+AA_TRANSLATIONS_MODEL = None
+
 # Languages we allow in the tool. list of ("Display Name", "language code https://libretranslate.com/languages") or leave as is for defaults
-# AA_TRANSLATIONS_LANGUAGES = []
+# If using "openai" the second entry in the tuple is what is passed to the model feel free to use the full language name for less ambiguity.
+# AA_TRANSLATIONS_LANGUAGES = [
+# ("English", "en"),
+# ]
 ```
+
+- When using `AA_TRANSLATIONS_PROVIDER = "libretranslate"`, the URL should point at your LibreTranslate instance and the API key can be omitted unless the instance enforces it.
+- When using `AA_TRANSLATIONS_PROVIDER = "openai"`, set the URL to an OpenAI-compatible base URL, provide a valid API key, and configure `AA_TRANSLATIONS_MODEL` with the target model name.
 
 ## Usage
 
@@ -46,4 +62,4 @@ AA_TRANSLATIONS_API_KEY= "i was generated from libretranslate"
 
 ## Libretranslate System Requirements
 
-Seems to be CPU bound using around 2gb of memory. On a 2 core, 4gb instance it takes around a minute to translate 60 words. 
+Seems to be CPU bound using around 2gb of memory. On a 2 core, 4gb instance it takes around a minute to translate 60 words.

--- a/aatranslate/app_settings.py
+++ b/aatranslate/app_settings.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 AA_TRANSLATIONS_LANGUAGES = getattr(
     settings,
-    'AA_TRANSLATIONS_LANGUAGES',
+    "AA_TRANSLATIONS_LANGUAGES",
     [
         ("English", "en"),
         ("Deutsch", "de"),
@@ -13,18 +13,19 @@ AA_TRANSLATIONS_LANGUAGES = getattr(
         ("Français", "fr"),
         ("日本語", "ja"),
         ("Italiano", "it"),
-        ("Українська", "uk")
-    ]
+        ("Українська", "uk"),
+    ],
 )
+
+AA_TRANSLATIONS_PROVIDER = getattr(
+    settings, "AA_TRANSLATIONS_PROVIDER", "libretranslate"
+)
+
 
 AA_TRANSLATIONS_URL = getattr(
-    settings,
-    'AA_TRANSLATIONS_URL',
-    "http://libretranslate:9095"
+    settings, "AA_TRANSLATIONS_URL", "http://libretranslate:9095"
 )
 
-AA_TRANSLATIONS_API_KEY = getattr(
-    settings,
-    'AA_TRANSLATIONS_API_KEY',
-    None
-)
+AA_TRANSLATIONS_API_KEY = getattr(settings, "AA_TRANSLATIONS_API_KEY", None)
+
+AA_TRANSLATIONS_MODEL = getattr(settings, "AA_TRANSLATIONS_MODEL", None)

--- a/aatranslate/providers.py
+++ b/aatranslate/providers.py
@@ -1,19 +1,22 @@
 from libretranslatepy import LibreTranslateAPI
+from openai import OpenAI
 
-from .app_settings import AA_TRANSLATIONS_API_KEY, AA_TRANSLATIONS_URL
+from .app_settings import (
+    AA_TRANSLATIONS_API_KEY,
+    AA_TRANSLATIONS_PROVIDER,
+    AA_TRANSLATIONS_MODEL,
+    AA_TRANSLATIONS_URL,
+)
 
 
 class LibreTranslateClient:
     def __init__(self):
         if AA_TRANSLATIONS_API_KEY:
             self.t = LibreTranslateAPI(
-                AA_TRANSLATIONS_URL,
-                api_key=AA_TRANSLATIONS_API_KEY
+                AA_TRANSLATIONS_URL, api_key=AA_TRANSLATIONS_API_KEY
             )
         else:
-            self.t = LibreTranslateAPI(
-                AA_TRANSLATIONS_URL
-            )
+            self.t = LibreTranslateAPI(AA_TRANSLATIONS_URL)
 
     def translate(self, text, source="auto", target="en"):
         output = self.t.translate(text, source, target)
@@ -24,4 +27,39 @@ class LibreTranslateClient:
         return output
 
 
-translate = LibreTranslateClient()
+class OpenAITranslateClient:
+    def __init__(self):
+        self.client = OpenAI(
+            base_url=AA_TRANSLATIONS_URL, api_key=AA_TRANSLATIONS_API_KEY
+        )
+
+    def translate(self, text, source="auto", target="en"):
+        completion = self.client.chat.completions.create(
+            extra_headers={},
+            extra_body={},
+            temperature=0,
+            model=AA_TRANSLATIONS_MODEL,
+            messages=[
+                {
+                    "role": "developer",
+                    "content": f"You are a translator. Translate strictly from {source} to {target}. Output only the translated text in full with no additions.",
+                },
+                {
+                    "role": "user",
+                    "content": text,
+                },
+            ],
+        )
+        return completion.choices[0].message.content.strip()
+
+    def languages(self):
+        return []
+
+
+translate = None
+if AA_TRANSLATIONS_PROVIDER == "libretranslate":
+    translate = LibreTranslateClient()
+elif AA_TRANSLATIONS_PROVIDER == "openai":
+    translate = OpenAITranslateClient()
+else:
+    raise Exception("Unknown translate provider")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "allianceauth<5.0.0,>=4",
     "allianceauth-discordbot<6.0.0,>=3.7.3",
     "libretranslatepy<3.0.0,>=2.1.4",
+    "openai<3.0.0,>=2.0.0"
 ]
 [project.urls]
 Home = "https://github.com/Solar-Helix-Independent-Transport/allianceauth-translate-tool"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "allianceauth<5.0.0,>=4",
+    "allianceauth<6.0.0,>=5",
     "allianceauth-discordbot<6.0.0,>=3.7.3",
     "libretranslatepy<3.0.0,>=2.1.4",
     "openai<3.0.0,>=2.0.0"


### PR DESCRIPTION
it is susceptible to prompt injection especially when using the free dumb models I was testing with. Working on fixing not sure if it can be fixed though. This is tested and working on my corps instance.

I deployed it with openrouter + one of the many free models they have there. I do not expect them to last but it preforms better translation than libretranslate in my experience.

Example free model [https://openrouter.ai/openai/gpt-oss-20b:free](https://openrouter.ai/openai/gpt-oss-20b:free)